### PR TITLE
Add accessible names to icon links

### DIFF
--- a/src/partials/Card.js
+++ b/src/partials/Card.js
@@ -24,15 +24,19 @@ function Card() {
           <div className="flex align-center justify-center mt-4">
             <a className="text-xl m-1 p-1 sm:m-2 sm:p-2 text-gray-800 hover:bg-gray-800 rounded-full hover:text-white transition-colors duration-300" href="https://github.com/BraydenTW">
               <FaGithub />
+              <span class="sr-only">Github</span>
             </a>
             <a className="text-xl m-1 p-1 sm:m-2 sm:p-2 text-pink-600 hover:bg-pink-600 rounded-full hover:text-white transition-colors duration-300" href="https://github.com/BraydenTW">
               <FaDribbble />
+              <span class="sr-only">Dribble</span>
             </a>
             <a className="text-xl m-1 p-1 sm:m-2 sm:p-2 text-blue-500 hover:bg-blue-500 rounded-full hover:text-white transition-colors duration-300" href="https://github.com/BraydenTW">
               <FaTwitter />
+              <span class="sr-only">Twitter</span>  
             </a>
             <a className="text-xl m-1 p-1 sm:m-2 sm:p-2 text-teal-500 hover:bg-teal-500 rounded-full hover:text-white transition-colors duration-300" href="https://github.com/BraydenTW">
               <FaRegEnvelope />
+              <span class="sr-only">Email</span>  
             </a>
           </div>
         </div>


### PR DESCRIPTION
Brayden, nice job putting this template together and sharing it. I noticed that the icon links do not have any accessible names, meaning screenreader users would not know what each link represents. I'm suggesting that you add accessible names using Tailwind's `sr-only` class. That there is no visual impact but it's much nicer for screenreader users to hear the words themselves rather than listen to a whole URL being read out.

I think it is especially useful to fix stuff like this in templates because everybody who uses a template inherits the accessibility decisions (good or bad) made by the developer.